### PR TITLE
Use new timeout block in tests

### DIFF
--- a/terraform_test.tf
+++ b/terraform_test.tf
@@ -102,7 +102,7 @@ resource "maas_vm_host" "tf_test_vm_host" {
   machine = maas_machine.tf_test_machine.id
   type    = "lxd"
 
-  timeout {
+  timeouts {
     create = "40m"
   }
 }

--- a/terraform_test.tf
+++ b/terraform_test.tf
@@ -101,15 +101,16 @@ resource "maas_machine" "tf_test_machine" {
 resource "maas_vm_host" "tf_test_vm_host" {
   machine = maas_machine.tf_test_machine.id
   type    = "lxd"
+
+  timeout {
+    create = "40m"
+  }
 }
 
 resource "maas_vm_host_machine" "tf_test_vm" {
   vm_host = maas_vm_host.tf_test_vm_host.id
   cores   = 1
   memory  = 2048
-  timeout {
-    create = "40m"
-  }
 }
 
 resource "maas_instance" "tf_test_vm_instance" {

--- a/terraform_test.tf
+++ b/terraform_test.tf
@@ -116,4 +116,7 @@ resource "maas_instance" "tf_test_vm_instance" {
   deploy_params {
     distro_series = var.distro_series
   }
+  timeout {
+    create = "40m"
+  }
 }

--- a/terraform_test.tf
+++ b/terraform_test.tf
@@ -107,6 +107,9 @@ resource "maas_vm_host_machine" "tf_test_vm" {
   vm_host = maas_vm_host.tf_test_vm_host.id
   cores   = 1
   memory  = 2048
+  timeout {
+    create = "40m"
+  }
 }
 
 resource "maas_instance" "tf_test_vm_instance" {
@@ -115,8 +118,5 @@ resource "maas_instance" "tf_test_vm_instance" {
   }
   deploy_params {
     distro_series = var.distro_series
-  }
-  timeout {
-    create = "40m"
   }
 }


### PR DESCRIPTION
VM hosts are hitting a timeout in system tests, let's use the [newly created](https://github.com/maas/terraform-provider-maas/pull/164) timeout field to lengthen this